### PR TITLE
CI testing: CircleCI _should_ run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,10 @@ jobs:
       - checkout
 
       - run:
+          name: Determine whether CI should run (don't if docs-only)
+          command: git diff develop --name-only | grep --quiet --invert-match '^docs'
+
+      - run:
           name: Installation pre-reqs
           command: pip install -U -r ./testinfra/requirements.txt
 

--- a/securedrop/version.py
+++ b/securedrop/version.py
@@ -1,1 +1,2 @@
+# No-op comment addition for testing CI
 __version__ = '0.4.2'


### PR DESCRIPTION
Testing new logic to skip CircleCI staging run (which takes about 45 minutes) if changes in PR are docs-only. 

The changes in this PR should indeed trigger a CircleCI run, because app-code files have changed.